### PR TITLE
PrivacyShield Compatibility

### DIFF
--- a/DynBoneWrangler/DynBoneWrangler.cs
+++ b/DynBoneWrangler/DynBoneWrangler.cs
@@ -54,7 +54,7 @@ namespace DynBoneWrangler
 
             private static void CheckShouldUpdate(Worker worker)
             {
-                float localUserFPS = worker.LocalUser.FPS;
+                float localUserFPS = worker.Engine.SystemInfo.ImmediateFPS;
                 
                 if (_shouldUpdate)
                 {


### PR DESCRIPTION
Gets the local user's FPS using Engine.SystemInfo.ImmediateFPS in case LocalUser.FPS is being spoofed by [PrivacyShield](https://github.com/hazre/ResonitePrivacyShield)